### PR TITLE
Fix zip upload

### DIFF
--- a/main.go
+++ b/main.go
@@ -1312,9 +1312,7 @@ func (conn *connection) putConfig(config []interface{}) error {
 }
 
 func (conn *connection) putZipConfig(zip *bytes.Buffer) error {
-	reader := bufio.NewReader(zip)
-
-	r, err := http.NewRequest("PUT", fmt.Sprintf("%s/config?force=true", conn.Node), reader)
+	r, err := http.NewRequest("PUT", fmt.Sprintf("%s/config?force=true", conn.Node), zip)
 	if err != nil {
 		// shouldn't happen if connection is sane
 		return fmt.Errorf("unable to create request: %v", err)


### PR DESCRIPTION
According to [this](https://golang.org/src/net/http/request.go?s=25171:25240#L796)
http.NewRequest accepts bytes.Buffer, bytes.Reader and strings.Reader
If the body is not any of those it gets set to -1